### PR TITLE
isElement check improvements, browser exports, bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "is-element",
+  "main": "is-element.js",
+  "version": "0.0.1",
+  "homepage": "https://github.com/amongiants/is-element",
+  "authors": [
+    "Jon Gacnik <jon@folderstudio.com> (http://jongacnik.com/)"
+  ],
+  "description": "Returns true if DOM element.",
+  "keywords": [
+    "element",
+    "dom",
+    "check",
+    "is"
+  ],
+  "license": "WTFPL"
+}

--- a/is-element.js
+++ b/is-element.js
@@ -1,6 +1,21 @@
-module.exports = function(value){
-  return value !== undefined
-    && typeof HTMLElement !== 'undefined'
-    && value instanceof HTMLElement
-    && value.nodeType === 1;
-}
+(function(root) {
+  function isElement(value) {
+    return (value && value.nodeType === 1) &&
+           (value && typeof value == 'object') &&
+           (Object.prototype.toString.call(value).indexOf('Element') > -1);
+  }
+
+  if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = isElement;
+    }
+    exports.isElement = isElement;
+  } else if (typeof define === 'function' && define.amd) {
+    define([], function() {
+      return isElement;
+    });
+  } else {
+    root.isElement = isElement;
+  }
+
+})(this);


### PR DESCRIPTION
Improve isElement checks by checking the objects stringified type
rather than using instanceof because instanceof throws an exception
if the HTMLElement constructor does not exist.

Modify exports to include AMD support and browser export.

Add bower support.
